### PR TITLE
fix: make divider constructor arg for roller utils

### DIFF
--- a/script/AutoRoller.s.sol
+++ b/script/AutoRoller.s.sol
@@ -49,7 +49,7 @@ contract TestnetDeploymentScript is Script {
         Periphery periphery = Periphery(AddressBook.PERIPHERY_1_3_0);
         Divider divider = Divider(spaceFactory.divider());
 
-        RollerUtils utils = new RollerUtils();
+        RollerUtils utils = new RollerUtils(address(divider));
 
         RollerPeriphery rollerPeriphery = new RollerPeriphery();
 

--- a/src/AutoRoller.sol
+++ b/src/AutoRoller.sol
@@ -856,7 +856,9 @@ contract RollerUtils {
     uint256 internal constant SECONDS_PER_YEAR = 31536000;
     uint256 internal constant ONE = 1e18;
 
-    address internal constant DIVIDER = 0x09B10E45A912BcD4E80a8A3119f0cfCcad1e1f12;
+    address internal immutable divider;
+
+    constructor(address _divider) { divider = _divider; }
 
     /// @notice Calculate a maturity timestamp around x months in the future on exactly the top of the month.
     /// @param monthsForward Number of months in to advance forward.
@@ -888,7 +890,7 @@ contract RollerUtils {
     /// @param space Maturity associated with the Series who's Space data this function is fetching.
     /// @return stretchedRate Rate implied by the previous Series stretched to the Space pool's timestretch period.
     function getNewTargetedRate(uint256 /* fallbackTargetedRate */, address adapter, uint256 prevMaturity, Space space) public returns (uint256) {
-        (, uint48 prevIssuance, , , , , uint256 iscale, uint256 mscale, ) = DividerLike(DIVIDER).series(adapter, prevMaturity);
+        (, uint48 prevIssuance, , , , , uint256 iscale, uint256 mscale, ) = DividerLike(divider).series(adapter, prevMaturity);
 
         require(mscale != 0);
 

--- a/src/test/AutoRoller.t.sol
+++ b/src/test/AutoRoller.t.sol
@@ -103,7 +103,7 @@ contract AutoRollerTest is Test {
             mockAdapterParams
         );
 
-        utils = new RollerUtils();
+        utils = new RollerUtils(address(divider));
 
         rollerPeriphery = new RollerPeriphery();
 


### PR DESCRIPTION
Context: https://github.com/sherlock-audit/2022-11-sense-judging/issues/19