### PR TITLE
fix: dont let previewWithdraw use the same rounding as previewRedeem

### DIFF
--- a/src/AutoRoller.sol
+++ b/src/AutoRoller.sol
@@ -547,7 +547,7 @@ contract AutoRoller is ERC4626 {
 
                 int256 answer = previewRedeem(guess.safeCastToUint()).safeCastToInt() - assets.safeCastToInt();
 
-                if (answer >= 0 && answer <= assets.mulWadDown(0.001e18).safeCastToInt() || (prevAnswer == answer)) { // Err on the side of overestimating shares needed. Could reduce precision for gas efficiency.
+                if (answer > 0 && answer <= assets.mulWadDown(0.001e18).safeCastToInt() || (prevAnswer == answer)) { // Err on the side of overestimating shares needed. Could reduce precision for gas efficiency.
                     break;
                 }
 


### PR DESCRIPTION
Context: https://github.com/sherlock-audit/2022-11-sense-judging/issues/30