### PR TITLE
chore: guard against very small previewedLPBal amounts getting truncated

### DIFF
--- a/src/AutoRoller.sol
+++ b/src/AutoRoller.sol
@@ -429,7 +429,8 @@ contract AutoRoller is ERC4626 {
                 .mulDivDown(_space.adjustedTotalSupply(), targetReserves);
 
             // Shares represent proportional ownership of LP shares the vault holds.
-            return previewedLPBal.mulDivDown(totalSupply, _space.balanceOf(address(this)));
+            shares = previewedLPBal.mulDivDown(totalSupply, _space.balanceOf(address(this)));
+            require(shares > 100); // Avoid truncation imprecisions.
         }
     }
 


### PR DESCRIPTION
Context: https://github.com/sherlock-audit/2022-11-sense-judging/issues/41