### PR TITLE
chore: remove  param and replace with type(AutoRoller).creationCode

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,6 +16,6 @@
       "prettier-plugin-solidity": "^1.0.0-beta.13"
     },
     "scripts": {
-      "lint": "prettier --write **.sol"
+      "lint": "prettier --write {src,script}/**/*.sol"
     }
 }

--- a/script/AutoRoller.s.sol
+++ b/script/AutoRoller.s.sol
@@ -58,8 +58,7 @@ contract TestnetDeploymentScript is Script {
             address(balancerVault),
             address(periphery),
             address(rollerPeriphery),
-            utils,
-            type(AutoRoller).creationCode
+            utils
         );
 
         console2.log("Auto Roller Factory:", address(arFactory));

--- a/src/AutoRollerFactory.sol
+++ b/src/AutoRollerFactory.sol
@@ -24,15 +24,13 @@ contract AutoRollerFactory is Trust, BaseSplitCodeFactory {
 
     mapping(address => AutoRoller[]) public rollers;
 
-    /// @dev `_creationCode` should equal `type(AutoRoller).creationCode`
     constructor(
         DividerLike _divider,
         address _balancerVault,
         address _periphery,
         address _rollerPeriphery,
-        RollerUtils _utils,
-        bytes memory _creationCode
-    ) Trust(msg.sender) BaseSplitCodeFactory(_creationCode) {
+        RollerUtils _utils
+    ) Trust(msg.sender) BaseSplitCodeFactory(type(AutoRoller).creationCode) {
         divider         = _divider;
         balancerVault   = _balancerVault;
         periphery       = PeripheryLike(_periphery);

--- a/src/test/AutoRoller.t.sol
+++ b/src/test/AutoRoller.t.sol
@@ -120,8 +120,7 @@ contract AutoRollerTest is Test {
             address(balancerVault),
             address(periphery),
             address(rollerPeriphery),
-            utils,
-            type(AutoRoller).creationCode
+            utils
         );
 
         mockAdapter.setIsTrusted(address(arFactory), true);


### PR DESCRIPTION
It seems like Etherscan does not support verifying a contract who have a bytecode param (or probably just a large bytes param).

Hence, we are removing the param from the AutoRollerFactory and just using `type(AutoRoller).creationCode`