### PR TITLE
feat: deploy roller and adapter

### DIFF
--- a/foundry.toml
+++ b/foundry.toml
@@ -4,7 +4,7 @@ out = 'out'
 test = 'src/test'
 libs = ['lib/solmate']
 verbosity = 3
-eth-rpc-url = "https://eth-goerli.alchemyapi.io/v2/JrCVyH87AyAZaGXaIaxhWce4x-JqR7z-"
+eth-rpc-url = "https://eth-mainnet.alchemyapi.io/v2/JrCVyH87AyAZaGXaIaxhWce4x-JqR7z-"
 optimizer_runs = 10000
 # Block mined at Wed Aug 26 2022 05:51:48 AM +UTC
 # fork_block_number = 7473900,

--- a/src/AutoRoller.sol
+++ b/src/AutoRoller.sol
@@ -37,6 +37,7 @@ interface YTLike {
 }
 
 interface PeripheryLike {
+    function deployAdapter(address, address, bytes memory) external returns (address);
     function sponsorSeries(address, uint256, bool) external returns (ERC20, YTLike);
     function swapYTsForTarget(address, uint256, uint256) external returns (uint256);
     function create(address, uint256) external returns (address);

--- a/src/AutoRollerAdapterDeployer.sol
+++ b/src/AutoRollerAdapterDeployer.sol
@@ -1,35 +1,37 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 pragma solidity 0.8.15;
-import { AutoRoller, PeripheryLike, OwnedAdapterLike } from "./AutoRoller.sol";
+import { AutoRoller, OwnedAdapterLike } from "./AutoRoller.sol";
+import { AutoRollerFactory } from "./AutoRollerFactory.sol";
+import { Divider } from "sense-v1-core/Divider.sol";
+import { Periphery } from "sense-v1-core/Periphery.sol";
 
 interface OwnableFactoryLike {
     function rlvFactory() external view returns (address);
     function deployAdapter(address, bytes memory) external returns (address);
 }
 
-interface AutoRollerFactoryLike {
-    function create(
-        OwnedAdapterLike,
-        address rewardRecipient,
-        uint256 targetDuration
-    ) external returns (AutoRoller);
-}
-
 contract AutoRollerAdapterDeployer {
-    PeripheryLike internal immutable periphery;
+    Divider public immutable divider;
 
-    constructor(address _periphery) {
-        periphery = PeripheryLike(_periphery);
+    constructor(address _divider) {
+        divider = Divider(_divider);
     }
 
-    /// @notice Deploys an OwnableERC4626Adapter contract
-    /// @param factory The factory
+    /// @notice Deploys an OwnableERC4626Adapter and a Roller contract
+    /// @param factory The adapter factory
     /// @param target The target address
     /// @param data ABI encoded reward tokens address array
     /// @param rewardRecipient The address of the reward recipient
-    /// @param targetDuration The duration of each series
+    /// @param targetDuration The targeted duration in months for newly rolled series
     function deploy(address factory, address target, bytes memory data, address rewardRecipient, uint256 targetDuration) external returns (address adapter, AutoRoller autoRoller) {
-        adapter = periphery.deployAdapter(factory, target, data);
-        autoRoller = AutoRollerFactoryLike(OwnableFactoryLike(factory).rlvFactory()).create(OwnedAdapterLike(adapter), rewardRecipient, targetDuration);
+        adapter = Periphery(divider.periphery()).deployAdapter(factory, target, data);
+        AutoRollerFactory rlvFactory = AutoRollerFactory(OwnableFactoryLike(factory).rlvFactory());
+        autoRoller = rlvFactory.create(OwnedAdapterLike(adapter), rewardRecipient, targetDuration);
+
+        emit RollerAdapterDeployed(address(autoRoller), adapter);
     }
+
+    /* ========== EVENTS ========== */
+
+    event RollerAdapterDeployed(address autoRoller, address adapter);
 }

--- a/src/AutoRollerAdapterDeployer.sol
+++ b/src/AutoRollerAdapterDeployer.sol
@@ -1,0 +1,35 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+pragma solidity 0.8.15;
+import { AutoRoller, PeripheryLike, OwnedAdapterLike } from "./AutoRoller.sol";
+
+interface OwnableFactoryLike {
+    function rlvFactory() external view returns (address);
+    function deployAdapter(address, bytes memory) external returns (address);
+}
+
+interface AutoRollerFactoryLike {
+    function create(
+        OwnedAdapterLike,
+        address rewardRecipient,
+        uint256 targetDuration
+    ) external returns (AutoRoller);
+}
+
+contract AutoRollerAdapterDeployer {
+    PeripheryLike internal immutable periphery;
+
+    constructor(address _periphery) {
+        periphery = PeripheryLike(_periphery);
+    }
+
+    /// @notice Deploys an OwnableERC4626Adapter contract
+    /// @param factory The factory
+    /// @param target The target address
+    /// @param data ABI encoded reward tokens address array
+    /// @param rewardRecipient The address of the reward recipient
+    /// @param targetDuration The duration of each series
+    function deploy(address factory, address target, bytes memory data, address rewardRecipient, uint256 targetDuration) external returns (address adapter, AutoRoller autoRoller) {
+        adapter = periphery.deployAdapter(factory, target, data);
+        autoRoller = AutoRollerFactoryLike(OwnableFactoryLike(factory).rlvFactory()).create(OwnedAdapterLike(adapter), rewardRecipient, targetDuration);
+    }
+}

--- a/src/RollerAdapterDeployer.sol
+++ b/src/RollerAdapterDeployer.sol
@@ -10,7 +10,7 @@ interface OwnableFactoryLike {
     function deployAdapter(address, bytes memory) external returns (address);
 }
 
-contract AutoRollerAdapterDeployer {
+contract RollerAdapterDeployer {
     Divider public immutable divider;
 
     constructor(address _divider) {

--- a/src/test/AutoRoller.t.sol
+++ b/src/test/AutoRoller.t.sol
@@ -77,7 +77,7 @@ contract AutoRollerTest is Test {
 
         scalingFactor = 10**(18 - target.decimals());
 
-        (balancerVault, spaceFactory) = (
+        (balancerVault, spaceFactory, divider, periphery) = (
             BalancerVault(AddressBook.BALANCER_VAULT),
             SpaceFactoryLike(AddressBook.SPACE_FACTORY_1_3_0),
             Divider(AddressBook.DIVIDER_1_2_0),

--- a/src/test/AutoRoller.t.sol
+++ b/src/test/AutoRoller.t.sol
@@ -77,7 +77,7 @@ contract AutoRollerTest is Test {
 
         scalingFactor = 10**(18 - target.decimals());
 
-        (balancerVault, spaceFactory, divider, periphery) = (
+        (balancerVault, spaceFactory) = (
             BalancerVault(AddressBook.BALANCER_VAULT),
             SpaceFactoryLike(AddressBook.SPACE_FACTORY_1_3_0),
             Divider(AddressBook.DIVIDER_1_2_0),

--- a/src/test/AutoRoller.t.sol
+++ b/src/test/AutoRoller.t.sol
@@ -77,12 +77,12 @@ contract AutoRollerTest is Test {
 
         scalingFactor = 10**(18 - target.decimals());
 
-        (balancerVault, spaceFactory) = (
+        (balancerVault, spaceFactory, divider, periphery) = (
             BalancerVault(AddressBook.BALANCER_VAULT),
-            SpaceFactoryLike(AddressBook.SPACE_FACTORY_1_3_0)
+            SpaceFactoryLike(AddressBook.SPACE_FACTORY_1_3_0),
+            Divider(AddressBook.DIVIDER_1_2_0),
+            Periphery(AddressBook.PERIPHERY_1_4_0)
         );
-        periphery = Periphery(AddressBook.PERIPHERY_1_4_0);
-        divider = Divider(spaceFactory.divider());
 
         vm.label(address(spaceFactory), "SpaceFactory");
         vm.label(address(divider), "Divider");
@@ -133,7 +133,7 @@ contract AutoRollerTest is Test {
         );
 
         // Start multisig (admin) prank calls   
-        vm.prank(AddressBook.SENSE_DEPLOYER);
+        vm.prank(AddressBook.SENSE_MULTISIG);
         periphery.onboardAdapter(address(mockAdapter), true);
 
         vm.prank(AddressBook.SENSE_MULTISIG);
@@ -149,15 +149,6 @@ contract AutoRollerTest is Test {
         deal(address(stake), address(this), 1e18);
         stake.allowance(address(this), address(autoRoller));
         stake.safeApprove(address(autoRoller), 1e18);
-
-        // Set protocol fees
-        vm.startPrank(AddressBook.SENSE_DEPLOYER);
-        ProtocolFeesController protocolFeesCollector = ProtocolFeesController(balancerVault.getProtocolFeesCollector());
-        Authentication authorizer = Authentication(balancerVault.getAuthorizer());
-        bytes32 actionId = Authentication(address(protocolFeesCollector)).getActionId(protocolFeesCollector.setSwapFeePercentage.selector);
-        authorizer.grantRole(actionId, address(this));
-        vm.stopPrank();
-        protocolFeesCollector.setSwapFeePercentage(0.1e18);
     }
 
     // Auth

--- a/src/test/AutoRollerAdapterDeployer.t.sol
+++ b/src/test/AutoRollerAdapterDeployer.t.sol
@@ -9,8 +9,10 @@ import { AddressBook } from "./utils/AddressBook.sol";
 import { MockERC20 } from "solmate/test/utils/mocks/MockERC20.sol";
 import { MockERC4626 } from "solmate/test/utils/mocks/MockERC4626.sol";
 import { AutoRollerAdapterDeployer } from "../AutoRollerAdapterDeployer.sol";
+import { AutoRollerFactory } from "../AutoRollerFactory.sol";
 import { AutoRoller, OwnedAdapterLike } from "../AutoRoller.sol";
 import { OwnableERC4626Factory } from "sense-v1-core/adapters/abstract/factories/OwnableERC4626Factory.sol";
+import { Divider } from "sense-v1-core/Divider.sol";
 import { Periphery } from "sense-v1-core/Periphery.sol";
 
 contract AutoRollerAdapterDeployerTest is Test {
@@ -29,24 +31,44 @@ contract AutoRollerAdapterDeployerTest is Test {
 
         adapterFactory = address(AddressBook.OWNABLE_ERC4626_FACTORY);
         
-        vm.prank(address(AddressBook.SENSE_MULTISIG));
-        Periphery periphery = Periphery(address(AddressBook.PERIPHERY_1_4_0));
+        vm.prank(AddressBook.SENSE_MULTISIG);
+        Divider divider = Divider(address(AddressBook.DIVIDER_1_2_0));
+        Periphery periphery = Periphery(divider.periphery());
         if (!periphery.factories(adapterFactory)) {
             periphery.setFactory(adapterFactory, true);
         }
 
-        vm.prank(address(AddressBook.SENSE_MULTISIG));
+        vm.prank(AddressBook.SENSE_MULTISIG);
         OwnableERC4626Factory(adapterFactory).supportTarget(address(target), true);
 
-        deployer = new AutoRollerAdapterDeployer(address(AddressBook.PERIPHERY_1_4_0));
+        deployer = new AutoRollerAdapterDeployer(address(divider));
     }
 
     function testDeployAdapterAndRoller() public {
+        vm.expectEmit(false, false, false, false);
+        emit AdapterDeployed(address(0));
+
+        vm.expectEmit(false, false, false, false);
+        emit RollerCreated(address(0), address(0));
+
+        vm.expectEmit(false, false, false, false);
+        emit RollerAdapterDeployed(address(0), address(0));
+
         (address adapter, AutoRoller ar) = deployer.deploy(address(adapterFactory), address(target), "", REWARDS_RECIPIENT, TARGET_DURATION);
         assertEq(address(ar.adapter()), adapter);
         
-        // quick test that the adapter has the expected interface.
+        // Quick tests that the adapter and autoroller have the expected interfaces.
         vm.expectRevert("UNTRUSTED");
         OwnedAdapterLike(adapter).openSponsorWindow();
+
+        // We expect the first roll to fail as it needs to make a small initial deposit in target.
+        vm.expectRevert("TRANSFER_FROM_FAILED");
+        AutoRoller(ar).roll();
     }
+
+     /* ========== EVENTS ========== */
+
+    event AdapterDeployed(address indexed adapter);
+    event RollerCreated(address indexed adapter, address autoRoller);
+    event RollerAdapterDeployed(address autoRoller, address adapter);
 }

--- a/src/test/AutoRollerAdapterDeployer.t.sol
+++ b/src/test/AutoRollerAdapterDeployer.t.sol
@@ -1,0 +1,52 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity 0.8.15;
+
+import { Vm } from "forge-std/Vm.sol";
+import { Test } from "forge-std/Test.sol";
+import { console } from "forge-std/console.sol";
+import { AddressBook } from "./utils/AddressBook.sol";
+
+import { MockERC20 } from "solmate/test/utils/mocks/MockERC20.sol";
+import { MockERC4626 } from "solmate/test/utils/mocks/MockERC4626.sol";
+import { AutoRollerAdapterDeployer } from "../AutoRollerAdapterDeployer.sol";
+import { AutoRoller, OwnedAdapterLike } from "../AutoRoller.sol";
+import { OwnableERC4626Factory } from "sense-v1-core/adapters/abstract/factories/OwnableERC4626Factory.sol";
+import { Periphery } from "sense-v1-core/Periphery.sol";
+
+contract AutoRollerAdapterDeployerTest is Test {
+    MockERC4626 target;
+    MockERC20 underlying;
+
+    address public constant REWARDS_RECIPIENT = address(0x1);
+    uint256 public constant TARGET_DURATION = 3;
+
+    AutoRollerAdapterDeployer deployer;
+    address adapterFactory;
+
+    function setUp() public {
+        underlying = new MockERC20("Underlying", "Underlying", 18);
+        target = new MockERC4626(underlying, "Target", "Target");
+
+        adapterFactory = address(AddressBook.OWNABLE_ERC4626_FACTORY);
+        
+        vm.prank(address(AddressBook.SENSE_MULTISIG));
+        Periphery periphery = Periphery(address(AddressBook.PERIPHERY_1_4_0));
+        if (!periphery.factories(adapterFactory)) {
+            periphery.setFactory(adapterFactory, true);
+        }
+
+        vm.prank(address(AddressBook.SENSE_MULTISIG));
+        OwnableERC4626Factory(adapterFactory).supportTarget(address(target), true);
+
+        deployer = new AutoRollerAdapterDeployer(address(AddressBook.PERIPHERY_1_4_0));
+    }
+
+    function testDeployAdapterAndRoller() public {
+        (address adapter, AutoRoller ar) = deployer.deploy(address(adapterFactory), address(target), "", REWARDS_RECIPIENT, TARGET_DURATION);
+        assertEq(address(ar.adapter()), adapter);
+        
+        // quick test that the adapter has the expected interface.
+        vm.expectRevert("UNTRUSTED");
+        OwnedAdapterLike(adapter).openSponsorWindow();
+    }
+}

--- a/src/test/AutoRollerAdapterDeployer.t.sol
+++ b/src/test/AutoRollerAdapterDeployer.t.sol
@@ -63,7 +63,7 @@ contract AutoRollerAdapterDeployerTest is Test {
 
         // We expect the first roll to fail as it needs to make a small initial deposit in target.
         vm.expectRevert("TRANSFER_FROM_FAILED");
-        AutoRoller(ar).roll();
+        ar.roll();
     }
 
      /* ========== EVENTS ========== */

--- a/src/test/RollerAdapterDeployer.t.sol
+++ b/src/test/RollerAdapterDeployer.t.sol
@@ -8,21 +8,21 @@ import { AddressBook } from "./utils/AddressBook.sol";
 
 import { MockERC20 } from "solmate/test/utils/mocks/MockERC20.sol";
 import { MockERC4626 } from "solmate/test/utils/mocks/MockERC4626.sol";
-import { AutoRollerAdapterDeployer } from "../AutoRollerAdapterDeployer.sol";
+import { RollerAdapterDeployer } from "../RollerAdapterDeployer.sol";
 import { AutoRollerFactory } from "../AutoRollerFactory.sol";
 import { AutoRoller, OwnedAdapterLike } from "../AutoRoller.sol";
 import { OwnableERC4626Factory } from "sense-v1-core/adapters/abstract/factories/OwnableERC4626Factory.sol";
 import { Divider } from "sense-v1-core/Divider.sol";
 import { Periphery } from "sense-v1-core/Periphery.sol";
 
-contract AutoRollerAdapterDeployerTest is Test {
+contract RollerAdapterDeployerTest is Test {
     MockERC4626 target;
     MockERC20 underlying;
 
     address public constant REWARDS_RECIPIENT = address(0x1);
     uint256 public constant TARGET_DURATION = 3;
 
-    AutoRollerAdapterDeployer deployer;
+    RollerAdapterDeployer deployer;
     address adapterFactory;
 
     function setUp() public {
@@ -41,7 +41,7 @@ contract AutoRollerAdapterDeployerTest is Test {
         vm.prank(AddressBook.SENSE_MULTISIG);
         OwnableERC4626Factory(adapterFactory).supportTarget(address(target), true);
 
-        deployer = new AutoRollerAdapterDeployer(address(divider));
+        deployer = new RollerAdapterDeployer(address(divider));
     }
 
     function testDeployAdapterAndRoller() public {

--- a/src/test/utils/AddressBook.sol
+++ b/src/test/utils/AddressBook.sol
@@ -3,19 +3,22 @@ pragma solidity 0.8.15;
 
 library AddressBook {
     // Mainnet
-    // address public constant SENSE_MULTISIG = 0xDd76360C26Eaf63AFCF3a8d2c0121F13AE864D57;
-    // address public constant DIVIDER_1_2_0 = 0x86bA3E96Be68563E41c2f5769F1AF9fAf758e6E0;
-    // address public constant PERIPHERY_1_4_0 = 0xFff11417a58781D3C72083CB45EF54d79Cd02437;
-    // address public constant SPACE_FACTORY_1_3_0 = 0x5f6e8e9C888760856e22057CBc81dD9e0494aA34;
-    // address public constant BALANCER_VAULT = 0xBA12222222228d8Ba445958a75a0704d566BF2C8;
-    // address public constant USDT = 0xdAC17F958D2ee523a2206206994597C13D831ec7;
+    address public constant SENSE_DEPLOYER = 0x59A181710F926Eae6FddfbF27a14259E8DD00cA2;
+    address public constant SENSE_MULTISIG = 0xDd76360C26Eaf63AFCF3a8d2c0121F13AE864D57;
+    address public constant DIVIDER_1_2_0 = 0x86bA3E96Be68563E41c2f5769F1AF9fAf758e6E0;
+    address public constant PERIPHERY_1_3_0 = 0xFff11417a58781D3C72083CB45EF54d79Cd02437;
+    address public constant PERIPHERY_1_4_0 = 0xaa17633AA5A3Cb56698838561161bdb16Cebb8E3;
+    address public constant SPACE_FACTORY_1_3_0 = 0x9e629751b3FE0b030C219e567156adCB70ad5541;
+    address public constant BALANCER_VAULT = 0xBA12222222228d8Ba445958a75a0704d566BF2C8;
+    address public constant USDT = 0xdAC17F958D2ee523a2206206994597C13D831ec7;
+    address public constant OWNABLE_ERC4626_FACTORY = 0x60cD94a921C651723AFcbA8030951F2EB3Ca572a;
 
     // Goerli
-    address public constant SENSE_MULTISIG = 0x19f3bF5d7F8A58945DA80eaA4131DF2958f7AA4A;
-    address public constant SENSE_DEPLOYER = 0xF13519734649F7464E5BE4aa91987A35594b2B16;
-    address public constant DIVIDER_1_2_0 = 0x09B10E45A912BcD4E80a8A3119f0cfCcad1e1f12;
-    address public constant PERIPHERY_1_4_0 = 0x4bCBA1316C95B812cC014CA18C08971Ce1C10861;
-    address public constant SPACE_FACTORY_1_3_0 = 0x1621cb1a1A4BA17aF0aD62c6142A7389C81e831D;
-    address public constant BALANCER_VAULT = 0x1aB16CB0cb0e5520e0C081530C679B2e846e4D37;
-    address public constant USDT = 0xC57BE6dc821b0B64068C797051cb1539cAF5C5bA;
+    // address public constant SENSE_MULTISIG = 0x19f3bF5d7F8A58945DA80eaA4131DF2958f7AA4A;
+    // address public constant SENSE_DEPLOYER = 0xF13519734649F7464E5BE4aa91987A35594b2B16;
+    // address public constant DIVIDER_1_2_0 = 0x09B10E45A912BcD4E80a8A3119f0cfCcad1e1f12;
+    // address public constant PERIPHERY_1_4_0 = 0x4bCBA1316C95B812cC014CA18C08971Ce1C10861;
+    // address public constant SPACE_FACTORY_1_3_0 = 0x1621cb1a1A4BA17aF0aD62c6142A7389C81e831D;
+    // address public constant BALANCER_VAULT = 0x1aB16CB0cb0e5520e0C081530C679B2e846e4D37;
+    // address public constant USDT = 0xC57BE6dc821b0B64068C797051cb1539cAF5C5bA;
 }


### PR DESCRIPTION
Closes GEN-1891

A convenience contract that deploys both a RLV & Adapter within a single TX. This is for better UX on the app.

![image](https://user-images.githubusercontent.com/1841215/213627761-27baa0c3-3308-400d-804a-8ce678f62ff8.png)

