### PR TITLE
fix(src/RollerAdapterDeployer): set caller as owner of the roller

### DIFF
--- a/src/RollerAdapterDeployer.sol
+++ b/src/RollerAdapterDeployer.sol
@@ -27,6 +27,7 @@ contract RollerAdapterDeployer {
         adapter = Periphery(divider.periphery()).deployAdapter(factory, target, data);
         AutoRollerFactory rlvFactory = AutoRollerFactory(OwnableFactoryLike(factory).rlvFactory());
         autoRoller = rlvFactory.create(OwnedAdapterLike(adapter), rewardRecipient, targetDuration);
+        autoRoller.setParam("OWNER", msg.sender);
 
         emit RollerAdapterDeployed(address(autoRoller), adapter);
     }

--- a/src/test/RollerAdapterDeployer.t.sol
+++ b/src/test/RollerAdapterDeployer.t.sol
@@ -64,6 +64,14 @@ contract RollerAdapterDeployerTest is Test {
         // We expect the first roll to fail as it needs to make a small initial deposit in target.
         vm.expectRevert("TRANSFER_FROM_FAILED");
         ar.roll();
+
+        // We expect the address calling deploy to be the owner of the roller.
+        uint256 cooldownPre = ar.cooldown();
+        ar.setParam("COOLDOWN", 5);
+        uint256 cooldownPost = ar.cooldown();
+
+        assertEq(cooldownPost, 5);
+        assertTrue(cooldownPre != cooldownPost);
     }
 
      /* ========== EVENTS ========== */


### PR DESCRIPTION
Otherwise the RollerAdapterDeployer will by default be the owner of the roller. Realized that I missed this in the review