### PR TITLE
GEN-2358: ensure Periphery v2 compatbility 

### DIFF
--- a/script/AutoRoller.s.sol
+++ b/script/AutoRoller.s.sol
@@ -48,7 +48,7 @@ contract TestnetDeploymentScript is Script {
             SpaceFactoryLike(AddressBook.SPACE_FACTORY_1_3_0)
         );
 
-        Periphery periphery = Periphery(AddressBook.PERIPHERY_1_4_0);
+        Periphery periphery = Periphery(payable(AddressBook.PERIPHERY_1_4_0));
         Divider divider = Divider(spaceFactory.divider());
 
         RollerUtils utils = new RollerUtils(address(divider));

--- a/script/RollerPeripheryV2.s.sol
+++ b/script/RollerPeripheryV2.s.sol
@@ -58,8 +58,9 @@ contract MainnetDeploymentScript is Script {
             BalancerVault(AddressBook.BALANCER_VAULT),
             SpaceFactoryLike(AddressBook.SPACE_FACTORY_1_3_0)
         );
+
         // TODO: replace for new periphery once its deployed
-        Periphery periphery = Periphery(AddressBook.PERIPHERY_1_4_0); 
+        Periphery periphery = Periphery(payable(AddressBook.PERIPHERY_1_4_0)); 
         Divider divider = Divider(spaceFactory.divider());
         AutoRollerFactory arFactory = AutoRollerFactory(AddressBook.RLV_FACTORY);
 
@@ -69,11 +70,12 @@ contract MainnetDeploymentScript is Script {
 
         vm.startBroadcast(deployer); // deploy from deployer address
 
-        RollerPeriphery rollerPeriphery = new RollerPeriphery(IPermit2(AddressBook.PERMIT2), AddressBook.EXCHANGE_PROXY);
-        console2.log("- RollerPeriphery deployed @ ", address(arFactory));
+        RollerPeriphery rollerPeriphery = RollerPeriphery(payable(0x8f66a9a5a4387092d34A4adC99f739819BE14869));
+        // RollerPeriphery rollerPeriphery = new RollerPeriphery(IPermit2(AddressBook.PERMIT2), AddressBook.EXCHANGE_PROXY);
+        console2.log("- RollerPeriphery deployed @ ", address(rollerPeriphery));
 
-        console.log("- Add AutoRoller factory as trusted on RollerPeriphery");
-        rollerPeriphery.setIsTrusted(address(arFactory), true);
+        // console.log("- Add AutoRoller factory as trusted on RollerPeriphery");
+        // rollerPeriphery.setIsTrusted(address(arFactory), true);
 
         _doApprovals(rollerPeriphery);
 
@@ -175,14 +177,25 @@ contract MainnetDeploymentScript is Script {
             ERC20 underlying = ERC20(adapter.underlying());
 
             // Allow the new roller to move the roller periphery's target
-            rollerPeriphery.approve(target, address(rlv));
+            if (target.allowance(address(rollerPeriphery), address(rlv)) == 0) {
+                console2.log("- ENTRE");
+                rollerPeriphery.approve(target, address(rlv));
+            } else {
+                console2.log("- NO ENTRE");
+            }
 
             // Allow the adapter to move the roller periphery's underlying & target if it can't already
             if (underlying.allowance(address(rollerPeriphery), address(adapter)) == 0) {
+                console2.log("- ENTRE1");
                 rollerPeriphery.approve(underlying, address(adapter));
+            } else {
+                console2.log("- NO ENTRE1");
             }
             if (target.allowance(address(rollerPeriphery), address(adapter)) == 0) {
+                console2.log("- ENTRE2");
                 rollerPeriphery.approve(target, address(adapter));
+            } else {
+                console2.log("- NO ENTRE2");
             }
         }
     }

--- a/script/RollerPeripheryV2.s.sol
+++ b/script/RollerPeripheryV2.s.sol
@@ -70,12 +70,11 @@ contract MainnetDeploymentScript is Script {
 
         vm.startBroadcast(deployer); // deploy from deployer address
 
-        RollerPeriphery rollerPeriphery = RollerPeriphery(payable(0x8f66a9a5a4387092d34A4adC99f739819BE14869));
-        // RollerPeriphery rollerPeriphery = new RollerPeriphery(IPermit2(AddressBook.PERMIT2), AddressBook.EXCHANGE_PROXY);
+        RollerPeriphery rollerPeriphery = new RollerPeriphery(IPermit2(AddressBook.PERMIT2), AddressBook.EXCHANGE_PROXY);
         console2.log("- RollerPeriphery deployed @ ", address(rollerPeriphery));
 
-        // console.log("- Add AutoRoller factory as trusted on RollerPeriphery");
-        // rollerPeriphery.setIsTrusted(address(arFactory), true);
+        console.log("- Add AutoRoller factory as trusted on RollerPeriphery");
+        rollerPeriphery.setIsTrusted(address(arFactory), true);
 
         _doApprovals(rollerPeriphery);
 
@@ -178,24 +177,15 @@ contract MainnetDeploymentScript is Script {
 
             // Allow the new roller to move the roller periphery's target
             if (target.allowance(address(rollerPeriphery), address(rlv)) == 0) {
-                console2.log("- ENTRE");
                 rollerPeriphery.approve(target, address(rlv));
-            } else {
-                console2.log("- NO ENTRE");
             }
 
             // Allow the adapter to move the roller periphery's underlying & target if it can't already
             if (underlying.allowance(address(rollerPeriphery), address(adapter)) == 0) {
-                console2.log("- ENTRE1");
                 rollerPeriphery.approve(underlying, address(adapter));
-            } else {
-                console2.log("- NO ENTRE1");
             }
             if (target.allowance(address(rollerPeriphery), address(adapter)) == 0) {
-                console2.log("- ENTRE2");
                 rollerPeriphery.approve(target, address(adapter));
-            } else {
-                console2.log("- NO ENTRE2");
             }
         }
     }

--- a/src/RollerAdapterDeployer.sol
+++ b/src/RollerAdapterDeployer.sol
@@ -24,7 +24,7 @@ contract RollerAdapterDeployer {
     /// @param rewardRecipient The address of the reward recipient
     /// @param targetDuration The targeted duration in months for newly rolled series
     function deploy(address factory, address target, bytes memory data, address rewardRecipient, uint256 targetDuration) external returns (address adapter, AutoRoller autoRoller) {
-        adapter = Periphery(divider.periphery()).deployAdapter(factory, target, data);
+        adapter = Periphery(payable(divider.periphery())).deployAdapter(factory, target, data);
         AutoRollerFactory rlvFactory = AutoRollerFactory(OwnableFactoryLike(factory).rlvFactory());
         autoRoller = rlvFactory.create(OwnedAdapterLike(adapter), rewardRecipient, targetDuration);
         autoRoller.setParam("OWNER", msg.sender);

--- a/src/test/AutoRoller.t.sol
+++ b/src/test/AutoRoller.t.sol
@@ -85,7 +85,7 @@ contract AutoRollerTest is Test, Permit2Helper {
             BalancerVault(AddressBook.BALANCER_VAULT),
             SpaceFactoryLike(AddressBook.SPACE_FACTORY_1_3_0),
             Divider(AddressBook.DIVIDER_1_2_0),
-            Periphery(AddressBook.PERIPHERY_1_4_0)
+            Periphery(payable(AddressBook.PERIPHERY_1_4_0))
         );
 
         vm.label(address(spaceFactory), "SpaceFactory");

--- a/src/test/RollerAdapterDeployer.t.sol
+++ b/src/test/RollerAdapterDeployer.t.sol
@@ -33,7 +33,7 @@ contract RollerAdapterDeployerTest is Test {
         
         vm.prank(AddressBook.SENSE_MULTISIG);
         Divider divider = Divider(address(AddressBook.DIVIDER_1_2_0));
-        Periphery periphery = Periphery(divider.periphery());
+        Periphery periphery = Periphery(payable(divider.periphery()));
         if (!periphery.factories(adapterFactory)) {
             periphery.setFactory(adapterFactory, true);
         }

--- a/src/test/RollerPeriphery.tm.sol
+++ b/src/test/RollerPeriphery.tm.sol
@@ -297,13 +297,15 @@ contract AutoRollerMainnetTest is Test, Permit2Helper {
         vm.stopPrank();
     }
 
-    function testMainnetCanDepositFromTargetRedeemToTarget_BREAKING() public {
-        // wstETH RLV
+    function testMainnetCanDepositFromTargetRedeemToTargetAfterSwitchingPeriphery() public {
         address WSTETH = 0x7f39C581F595B53c5cb19bD0b3f8dA6c935E2Ca0;
-        autoRoller = AutoRoller(0xeb9e7e1F892Bb2931e8C319D6F10FDf147090818);
+        autoRoller = AutoRoller(0xeb9e7e1F892Bb2931e8C319D6F10FDf147090818); // wstETH RLV
+        adapter = OwnableERC4626Adapter(address(autoRoller.adapter()));
+        uint256 maturity = autoRoller.maturity(); // 1st July 2023
+        address YT = divider.yt(address(adapter), maturity);
 
         // deploy Periphery v2
-        Periphery periphery = new Periphery(
+        Periphery peripheryV2 = new Periphery(
             address(divider),
             address(spaceFactory),
             address(balancerVault),
@@ -312,65 +314,82 @@ contract AutoRollerMainnetTest is Test, Permit2Helper {
         );
 
         // onboard wstETH adapter on Periphery
-        vm.prank(AddressBook.SENSE_MULTISIG);
-        periphery.onboardAdapter(address(autoRoller.adapter()), false);
+        peripheryV2.onboardAdapter(address(adapter), false);
 
         // verify wstETH adapter on Periphery
-        vm.prank(AddressBook.SENSE_MULTISIG);
-        periphery.verifyAdapter(address(autoRoller.adapter()));
+        peripheryV2.verifyAdapter(address(adapter));
 
         // set Periphery on divider
         vm.prank(AddressBook.SENSE_MULTISIG);
-        divider.setPeriphery(address(periphery));
+        divider.setPeriphery(address(peripheryV2));
 
         // set Periphery on RLV
         vm.prank(0x59A181710F926Eae6FddfbF27a14259E8DD00cA2); // deployer address
-        autoRoller.setParam("PERIPHERY", address(periphery));
+        autoRoller.setParam("PERIPHERY", address(peripheryV2));
 
         // approve RLV to spend RollerPeriphery's wstETH from trusted address
         rollerPeriphery.approve(ERC20(WSTETH), address(autoRoller));
-        // rollerPeriphery.approve(underlying, address(adapter));
-        // rollerPeriphery.approve(target, address(adapter));
-
-        // approve Periphery to pull RLV's YTs 
-        // FIXME: this should be done via a function on the autoRoller contract 
-        // UNCOMMENT THIS TO MAKE THE TEST PASS
-        // vm.prank(address(autoRoller));
-        // address YT = 0x98eA92eB1f51853a2Cf25dA655A2F6fb51E58675; // 1st July 2023 sY-wstETH
-        // ERC20(YT).approve(address(periphery), 0.1e18);
 
         vm.startPrank(alice);
 
-        // Load alice's wallet, approve pertmi2, generate permit message and quote to swap USDC to underlying (DAI) 
+        // Load alice's wallet, approve permit2, generate permit message and quote
         deal(WSTETH, alice, 0.1e18);
         ERC20(WSTETH).approve(AddressBook.PERMIT2, 0.1e18);
         RollerPeriphery.PermitData memory data = _generatePermit(alicePrivKey, address(rollerPeriphery), WSTETH);
         RollerPeriphery.SwapQuote memory quote = _getQuote(address(adapter), WSTETH, address(0));
 
-        // Deposit
-        uint256 wstETHBalBefore = ERC20(WSTETH).balanceOf(alice);
-        uint256 previewedDeposit = autoRoller.previewDeposit(0.1e18);
-        uint256 actualDeposit = rollerPeriphery.deposit(autoRoller, 0.1e18, alice, 0, data, quote);
-        uint256 wstETHBalAfter = ERC20(WSTETH).balanceOf(alice);
-        // assertEq(wstETHBalBefore - wstETHBalAfter, 0.1e18);
-        // assertEq(previewedDeposit, actualDeposit);
-        // assertEq(actualDeposit, autoRoller.balanceOf(alice));
+        // can deposit
+        rollerPeriphery.deposit(autoRoller, 0.1e18, alice, 0, data, quote);
 
-        // Redeem
+        // can't redeem because periphery has been switched
         ERC20(address(autoRoller)).approve(AddressBook.PERMIT2, 0.05e18);
         data = _generatePermit(alicePrivKey, address(rollerPeriphery), address(autoRoller));
         quote = _getQuote(address(adapter), address(0), WSTETH);
-        wstETHBalBefore = ERC20(WSTETH).balanceOf(alice);
-        uint256 previewedRedeem = autoRoller.previewRedeem(0.05e18);
-        uint256 actualRedeem = rollerPeriphery.redeem(autoRoller, 0.05e18, alice, 0, data, quote);
-       
-        // wstETHBalAfter = ERC20(WSTETH).balanceOf(alice);
-        // uint256 sharesBalAfter = autoRoller.balanceOf(alice);
-        // assertEq(actualRedeem, previewedRedeem);
-        // assertEq(0.05e18 - sharesBalAfter, 0.05e18);
-        // assertEq(wstETHBalAfter - wstETHBalBefore, actualRedeem);
+
+        // we expect redeem to revert
+        vm.expectRevert();
+        rollerPeriphery.redeem(autoRoller, 0.02e18, alice, 0, data, quote);
 
         vm.stopPrank();
+
+        // we can redeem if we force the approval of YTs
+        // approve Periphery to pull RLV's 0.05 YTs 
+        vm.prank(address(autoRoller));
+        ERC20(YT).approve(address(peripheryV2), 0.01e18);
+        vm.prank(alice);
+        rollerPeriphery.redeem(autoRoller, 0.02e18, alice, 0, data, quote);
+
+        // we can also redeem if we set the previous periphery back
+        // approve Periphery to pull RLV's 0.05 YTs 
+        vm.prank(AddressBook.SENSE_MULTISIG);
+        divider.setPeriphery(address(periphery));
+        vm.prank(0x59A181710F926Eae6FddfbF27a14259E8DD00cA2); // deployer address
+        autoRoller.setParam("PERIPHERY", address(periphery));
+
+        data = _generatePermit(alicePrivKey, address(rollerPeriphery), address(autoRoller));
+        vm.prank(alice);
+        rollerPeriphery.redeem(autoRoller, 0.02e18, alice, 0, data, quote);
+        
+        // warp to maturity, settle and start cooldown
+        vm.warp(maturity);
+        vm.prank(0xe09fE5ACb74c1d98507f87494Cf6AdEBD3B26b1e); // roller address
+        autoRoller.settle();
+
+        // set the Periphery V2 again
+        vm.prank(AddressBook.SENSE_MULTISIG);
+        divider.setPeriphery(address(peripheryV2));
+        vm.prank(0x59A181710F926Eae6FddfbF27a14259E8DD00cA2); // deployer address
+        autoRoller.setParam("PERIPHERY", address(peripheryV2));
+
+        // warp to cooldown and roll
+        vm.warp(maturity + autoRoller.cooldown());
+        vm.prank(0xe09fE5ACb74c1d98507f87494Cf6AdEBD3B26b1e); // roller address
+        autoRoller.roll();
+
+        // can now redeem normally
+        data = _generatePermit(alicePrivKey, address(rollerPeriphery), address(autoRoller));
+        vm.prank(alice);
+        rollerPeriphery.redeem(autoRoller, 0.01e18, alice, 0, data, quote);
     }
 
     function _getQuote(


### PR DESCRIPTION
We are adding a test to ensure that RLVs remain compatible with Periphery v2 in case there's a Periphery switch on existing RLVs.